### PR TITLE
ci: upgrade Linux runners from Ubuntu 22.04 to 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
           - macos-14
           - macos-15
           - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - macos-14
           - macos-15
-          - ubuntu-22.04
+          - ubuntu-24.04
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:

--- a/Formula/akv.rb
+++ b/Formula/akv.rb
@@ -1,8 +1,8 @@
 class Akv < Formula
   desc "Azure Key Vault CLI"
   homepage "https://github.com/heaths/akv-cli-rs"
-  url "https://github.com/heaths/akv-cli-rs/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "aa90f6d96d01b44f92d7d4c2a1a504196c9f46dabd58d037c65f5493a40a735c"
+  url "https://github.com/heaths/akv-cli-rs/archive/refs/tags/v0.11.1.tar.gz"
+  sha256 "420ffaef6fdf0359fb5308111a1698fa5654cba05c91b1714caac21bfbfb037f"
   license "MIT"
   head "https://github.com/heaths/akv-cli-rs.git", branch: "main"
 

--- a/Formula/akv.rb
+++ b/Formula/akv.rb
@@ -1,8 +1,8 @@
 class Akv < Formula
   desc "Azure Key Vault CLI"
   homepage "https://github.com/heaths/akv-cli-rs"
-  url "https://github.com/heaths/akv-cli-rs/archive/refs/tags/v0.11.1.tar.gz"
-  sha256 "420ffaef6fdf0359fb5308111a1698fa5654cba05c91b1714caac21bfbfb037f"
+  url "https://github.com/heaths/akv-cli-rs/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "aa90f6d96d01b44f92d7d4c2a1a504196c9f46dabd58d037c65f5493a40a735c"
   license "MIT"
   head "https://github.com/heaths/akv-cli-rs.git", branch: "main"
 


### PR DESCRIPTION
`brew doctor` now fails on Ubuntu 22.04 because glibc 2.35 is below Homebrew's minimum, causing `brew test-bot --only-setup` to exit non-zero.

## Changes

- Replace `ubuntu-22.04` and `ubuntu-22.04-arm` with `ubuntu-24.04` and `ubuntu-24.04-arm` in the test matrix — both ship with glibc 2.39, satisfying Homebrew's requirement.